### PR TITLE
feat: add MovesPage component to display shuttle swap logs

### DIFF
--- a/src/app/dashboard/shuttles/locations/moves/_actions/index.ts
+++ b/src/app/dashboard/shuttles/locations/moves/_actions/index.ts
@@ -1,0 +1,24 @@
+"use server";
+import db from "@/db/db";
+
+//move type
+export type ShuttleMove = {
+	ID: string;
+	timestamp: Date;
+	aisle: number;
+	level: number;
+	oldMacAddress: string;
+	newMacAddress: string;
+	oldShuttleID: string;
+	newShuttleID: string;
+};
+
+export async function getAllShuttleMoves(): Promise<ShuttleMove[]> {
+	const moves = await db.dmsShuttleSwapLogs.findMany({
+		orderBy: {
+			timestamp: "desc",
+		},
+	});
+
+	return moves;
+}

--- a/src/app/dashboard/shuttles/locations/moves/page.tsx
+++ b/src/app/dashboard/shuttles/locations/moves/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useEffect, useState } from "react";
+
+import { getAllShuttleMoves } from "./_actions";
+import { ShuttleMove } from "./_actions";
+
+import PanelTop from "@/components/panels/panelTop";
+import { getTeamColourFromDateToTW } from "@/utils/getTeamColour";
+
+export default function MovesPage() {
+	const [moves, setMoves] = useState<ShuttleMove[]>([]);
+
+	useEffect(() => {
+		async function fetchMoves() {
+			const movesData = await getAllShuttleMoves();
+
+			setMoves(movesData);
+		}
+		fetchMoves();
+	}, []);
+
+	return (
+		<PanelTop className="w-full" title={"Shuttle Swaps "}>
+			<div>
+				<table className="w-full">
+					<thead className="border border-black bg-orange-400">
+						<tr>
+							<th style={{ width: "150px" }}>Timestamp</th>
+							<th style={{ width: "150px" }}>Aisle</th>
+							<th style={{ width: "100px" }}>Level</th>
+							<th style={{ width: "100px" }}>Old Shuttle ID</th>
+							<th style={{ width: "100px" }}>New Shuttle ID</th>
+						</tr>
+					</thead>
+
+					<tbody>
+						{moves.length === 0 ? (
+							<tr>
+								<td className="text-center" colSpan={6}>
+									No moves found for the selected location and date range.
+								</td>
+							</tr>
+						) : (
+							moves.map((move) => {
+								return makeMoveRow(move);
+							})
+						)}
+					</tbody>
+				</table>
+			</div>
+		</PanelTop>
+	);
+}
+
+function makeMoveRow(move: ShuttleMove) {
+	return (
+		<tr
+			key={move.ID}
+			className="border border-black text-center hover:bg-yellow-400"
+		>
+			<td className={getTeamColourFromDateToTW(move.timestamp)}>
+				{" "}
+				{new Date(move.timestamp).toLocaleString()}
+			</td>
+			<td>{move.aisle}</td>
+			<td>{move.level}</td>
+			<td>{move.oldShuttleID}</td>
+			<td>{move.newShuttleID}</td>
+		</tr>
+	);
+}

--- a/src/app/dashboard/shuttles/locations/page.tsx
+++ b/src/app/dashboard/shuttles/locations/page.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { DndContext } from "@dnd-kit/core";
 import { toast } from "react-toastify";
+import Link from "next/link";
 
 import { shuttleLocation, shuttleLocationEnum } from "../_types/shuttle";
 
@@ -600,6 +601,11 @@ export default function Home() {
 					</DropColumn>
 				</div>
 			</DndContext>
+			<Link className="text-white" href={"/dashboard/shuttles/locations/moves"}>
+				<button className="mt-2 rounded bg-blue-500 p-2 hover:bg-blue-700">
+					View Shuttle Moves
+				</button>
+			</Link>
 		</PanelTop>
 	);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Shuttle Moves page displaying move history in a sortable timestamp-based table.
  - Move records include timestamp, aisle, level, previous shuttle ID, and new shuttle ID.
  - Added an accessible “View Shuttle Moves” navigation option from Shuttle Locations.
  - Displays a clear empty state when no shuttle moves are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->