### PR TITLE
fix: correct team color assignment for 28-04 to 01-05 cycle

### DIFF
--- a/src/utils/getTeamColour.ts
+++ b/src/utils/getTeamColour.ts
@@ -46,7 +46,7 @@ export const getTeamColourFromDateToTW = (date: Date): string => {
 	} else if (cyclePosition < 12) {
 		// 28-04 to 01-05
 		team =
-			hourOfDay >= 7 && hourOfDay < 19 ? TeamColours.GREEN : TeamColours.BLUE;
+			hourOfDay >= 7 && hourOfDay < 19 ? TeamColours.BLUE : TeamColours.GREEN;
 	} else {
 		// 02-05 to 05-05
 		team =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected team color assignments during the daily schedule, ensuring the appropriate color is displayed for daytime and nighttime periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->